### PR TITLE
Add the official Lamplit Labs X link

### DIFF
--- a/src/ui/app/page.tsx
+++ b/src/ui/app/page.tsx
@@ -230,6 +230,14 @@ function GitHubIcon() {
   );
 }
 
+function XIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
 function IconCard({
   icon,
   view,
@@ -661,6 +669,16 @@ export default function Home() {
                   title="GitHub"
                 >
                   <GitHubIcon />
+                </a>
+                <a
+                  href="https://x.com/lamplitlabs"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center rounded-lg border p-2 text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-all duration-200"
+                  title="X"
+                  aria-label="X"
+                >
+                  <XIcon />
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add https://x.com/lamplitlabs exactly once to each existing organization social list touched in this repository
- leave unrelated content and repositories without social surfaces unchanged
- keep retired Mastodon and Threads account links absent

## Validation
- Production build passed